### PR TITLE
Add transaction parser, cleanup utility, and Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,34 @@
+PYTHON ?= python3
+.RECIPEPREFIX := >
+
+# Default file locations (override when invoking, e.g. `make parse-pdf PDF=foo.pdf`)
+PDF ?=
+CSV ?=transactions.csv
+JSON ?=transactions.json
+TXT ?=
+EXCEL ?=output.xlsx
+TEMPLATE ?=invoice.pdf
+OUTPUT ?=filled_invoice.pdf
+
+.PHONY: help parse-pdf parse-txt invoices clean
+
+help:
+> @echo "Available targets:"
+> @echo "  parse-pdf   PDF=path/to/file [CSV=out.csv JSON=out.json]"
+> @echo "  parse-txt   TXT=path/to/file [CSV=out.csv JSON=out.json EXCEL=out.xlsx]"
+> @echo "  invoices    TEMPLATE=invoice.pdf OUTPUT=filled_invoice.pdf"
+> @echo "  clean       Remove generated CSV/JSON/Excel/PDF files"
+
+parse-pdf:
+> $(PYTHON) parse_transactions.py $(PDF) --csv $(CSV) --json $(JSON)
+
+parse-txt:
+> $(PYTHON) txt_journal_parser.py $(TXT) --csv $(CSV) --json $(JSON) --excel $(EXCEL)
+
+invoices:
+> $(PYTHON) generateInvoice.py $(TEMPLATE) $(OUTPUT)
+
+clean:
+> $(PYTHON) cleanup_outputs.py --csv $(wildcard *.csv) \
+>     --json $(wildcard *.json) --excel $(wildcard *.xlsx) \
+>     --pdf $(wildcard filled_invoice*.pdf)

--- a/cleanup_outputs.py
+++ b/cleanup_outputs.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Utility to remove generated output files."""
+
+import argparse
+from pathlib import Path
+from typing import Iterable
+
+
+def _remove_files(paths: Iterable[str]) -> None:
+    for name in paths:
+        p = Path(name)
+        if p.exists():
+            p.unlink()
+            print(f"Removed {p}")
+        else:
+            print(f"Skipping missing file {p}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Delete generated output files")
+    parser.add_argument("--csv", nargs="*", default=[], help="CSV files to remove")
+    parser.add_argument("--json", nargs="*", default=[], help="JSON files to remove")
+    parser.add_argument("--excel", nargs="*", default=[], help="Excel files to remove")
+    parser.add_argument("--pdf", nargs="*", default=[], help="PDF files to remove")
+    args = parser.parse_args()
+
+    if not any([args.csv, args.json, args.excel, args.pdf]):
+        print("No files specified for cleanup.")
+        return
+
+    _remove_files(args.csv)
+    _remove_files(args.json)
+    _remove_files(args.excel)
+    _remove_files(args.pdf)
+
+
+if __name__ == "__main__":
+    main()

--- a/parse_transactions.py
+++ b/parse_transactions.py
@@ -91,11 +91,20 @@ def export_data(records, csv_path, json_path):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
-        description="Extract transaction details from a PDF and export to CSV/JSON")
-    
-    parser.add_argument("pdf file", help="Path to the transaction PDF")
-    parser.add_argument("--csv", default="transactions.csv", help="output CSV file parth")
-    parser.add_argument("--json", default="transactions.json", help="Output JSON file path")
+        description="Extract transaction details from a PDF and export to CSV/JSON",
+    )
+
+    parser.add_argument("pdf_file", help="Path to the transaction PDF")
+    parser.add_argument(
+        "--csv",
+        default="transactions.csv",
+        help="Output CSV file path",
+    )
+    parser.add_argument(
+        "--json",
+        default="transactions.json",
+        help="Output JSON file path",
+    )
     args = parser.parse_args()
 
     records = parse_transaction_pdf(args.pdf_file)


### PR DESCRIPTION
## Summary
- add `parse_transactions.py` with a proper CLI to export PDF transaction details
- provide `cleanup_outputs.py` utility for removing generated CSV/JSON/Excel/PDF files
- introduce a Makefile with targets for parsing, invoice generation, and cleaning outputs

## Testing
- `python -m py_compile parse_transactions.py cleanup_outputs.py`
- `python cleanup_outputs.py --help`
- `make help`
- `make clean`
- `python parse_transactions.py --help` *(fails: No module named 'pdfplumber')*
- `pip install pdfplumber` *(fails: Tunnel connection failed: 403 Forbidden)*


------
https://chatgpt.com/codex/tasks/task_b_6895fc966f748321bcebbe82c24fb7ae