### PR TITLE
Add transaction parser, cleanup utility, and batch invoice generator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,40 @@
+PYTHON ?= python3
+.RECIPEPREFIX := >
+
+# Default file locations (override when invoking, e.g. `make parse-pdf PDF=foo.pdf`)
+PDF ?=
+CSV ?=transactions.csv
+JSON ?=transactions.json
+TXT ?=
+EXCEL ?=output.xlsx
+TEMPLATE ?=invoice.pdf
+OUTPUT ?=filled_invoice.pdf
+DB ?=database/bistro54_clients.db
+OUTDIR ?=.
+
+.PHONY: help parse-pdf parse-txt invoices batch-invoices clean
+
+help:
+> @echo "Available targets:"
+> @echo "  parse-pdf   PDF=path/to/file [CSV=out.csv JSON=out.json]"
+> @echo "  parse-txt   TXT=path/to/file [CSV=out.csv JSON=out.json EXCEL=out.xlsx]"
+> @echo "  invoices    TEMPLATE=invoice.pdf OUTPUT=filled_invoice.pdf"
+> @echo "  batch-invoices JSON=transactions.json TEMPLATE=invoice.pdf [DB=database/bistro54_clients.db OUTDIR=. ]"
+> @echo "  clean       Remove generated CSV/JSON/Excel/PDF files"
+
+parse-pdf:
+> $(PYTHON) parse_transactions.py $(PDF) --csv $(CSV) --json $(JSON)
+
+parse-txt:
+> $(PYTHON) txt_journal_parser.py $(TXT) --csv $(CSV) --json $(JSON) --excel $(EXCEL)
+
+invoices:
+> $(PYTHON) generateInvoice.py $(TEMPLATE) $(OUTPUT)
+
+batch-invoices:
+> $(PYTHON) generate_invoices.py $(JSON) $(TEMPLATE) --db $(DB) --out-dir $(OUTDIR)
+
+clean:
+> $(PYTHON) cleanup_outputs.py --csv $(wildcard *.csv) \
+>     --json $(wildcard *.json) --excel $(wildcard *.xlsx) \
+>     --pdf $(wildcard filled_invoice*.pdf)

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,6 @@ TEMPLATE ?=invoice.pdf
 OUTPUT ?=filled_invoice.pdf
 DB ?=database/bistro54_clients.db
 OUTDIR ?=.
-
 .PHONY: help parse-pdf parse-txt invoices batch-invoices clean
 
 help:
@@ -30,10 +29,8 @@ parse-txt:
 
 invoices:
 > $(PYTHON) generateInvoice.py $(TEMPLATE) $(OUTPUT)
-
 batch-invoices:
 > $(PYTHON) generate_invoices.py $(JSON) $(TEMPLATE) --db $(DB) --out-dir $(OUTDIR)
-
 clean:
 > $(PYTHON) cleanup_outputs.py --csv $(wildcard *.csv) \
 >     --json $(wildcard *.json) --excel $(wildcard *.xlsx) \

--- a/README.md
+++ b/README.md
@@ -49,8 +49,9 @@ This project provides scripts to:
 ├── README.md
 ├── txt_journal_parser.py # Parses TXT dumps to CSV/JSON/Excel
 ├── parse_transactions.py # Extracts detailed transactions from PDF
-├── generateInvoice.py # Fills PDF invoice template with data
-├── cleanup_outputs.py # Deletes generated CSV/JSON/Excel/PDF files
+├── generateInvoice.py      # Fills a single PDF invoice template with data
+├── generate_invoices.py    # Batch-generate invoices from transaction JSON
+├── cleanup_outputs.py      # Deletes generated CSV/JSON/Excel/PDF files
 ├── invoice.pdf # Blank invoice template
 └── venv/ # Python virtual environment
 
@@ -69,40 +70,51 @@ python3 parse_transactions.py path/to/DOC080725-001.pdf \
 
 This produces one row per item with columns:
 client_code, date (YYYY-MM-DD), time (HH:MM), reference, employee, description, price.
-2. Parse Journal Entries (TXT)
+### 2. Parse Journal Entries (TXT)
 
+```bash
 python3 txt_journal_parser.py path/to/journal.txt \
   --csv ar.csv --json ar.json --excel ar.xlsx
+```
 
-    --csv: Path to output CSV file (default: output.csv).
+* `--csv`: Path to output CSV file (default: output.csv).
+* `--json`: Path to output JSON file (default: output.json).
+* `--excel`: Path to output Excel file (default: output.xlsx).
 
-    --json: Path to output JSON file (default: output.json).
+### 3. Generate a Single Invoice
 
-    --excel: Path to output Excel file (default: output.xlsx).
-
-3. Generate Invoices
-
+```bash
 python3 generateInvoice.py invoice.pdf filled_invoice.pdf
+```
 
-    invoice.pdf: Path to your blank template.
+* `invoice.pdf`: Path to your blank template.
+* `filled_invoice.pdf`: Destination for the populated invoice.
 
-    filled_invoice.pdf: Destination for the populated invoice.
+### 4. Generate Invoices for Each Client
 
-Customize generateInvoice.py to loop over parsed data and produce one PDF per customer or per day.
-4. Cleanup Outputs
+```bash
+python3 generate_invoices.py transactions.json invoice.pdf \
+  --db database/bistro54_clients.db --out-dir invoices
+```
 
+Reads `transactions.json`, groups records by `client_code`, looks up client names from the SQLite database, and writes one `filled_invoice_<code>.pdf` per client in the `invoices/` directory.
+
+### 5. Cleanup Outputs
+
+```bash
 python3 cleanup_outputs.py --csv ar.csv --json ar.json --excel ar.xlsx
+```
 
 Removes specified output files if they exist.
-5. Makefile Targets
 
+### 6. Makefile Targets
+
+```
 make           # Show help
 make clean     # Remove all *.csv, *.json, *.xlsx, *.pdf outputs
+```
 
-Next Steps
+## Next Steps
 
-    Group extracted transactions by client_code and pass to the invoice generator so each customer’s visits appear as separate line-items.
-
-    Swap in API calls once Veloce API credentials are available to replace PDF/TXT parsing.
-
-    Add error handling, logging, and automated scheduling (cron, cloud scheduler, etc.).
+* Replace PDF/TXT parsing with Veloce API calls when credentials are available.
+* Add error handling, logging, and automated scheduling (cron, cloud scheduler, etc.).

--- a/cleanup_outputs.py
+++ b/cleanup_outputs.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Utility to remove generated output files."""
+
+import argparse
+from pathlib import Path
+from typing import Iterable
+
+
+def _remove_files(paths: Iterable[str]) -> None:
+    for name in paths:
+        p = Path(name)
+        if p.exists():
+            p.unlink()
+            print(f"Removed {p}")
+        else:
+            print(f"Skipping missing file {p}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Delete generated output files")
+    parser.add_argument("--csv", nargs="*", default=[], help="CSV files to remove")
+    parser.add_argument("--json", nargs="*", default=[], help="JSON files to remove")
+    parser.add_argument("--excel", nargs="*", default=[], help="Excel files to remove")
+    parser.add_argument("--pdf", nargs="*", default=[], help="PDF files to remove")
+    args = parser.parse_args()
+
+    if not any([args.csv, args.json, args.excel, args.pdf]):
+        print("No files specified for cleanup.")
+        return
+
+    _remove_files(args.csv)
+    _remove_files(args.json)
+    _remove_files(args.excel)
+    _remove_files(args.pdf)
+
+
+if __name__ == "__main__":
+    main()

--- a/generateInvoice.py
+++ b/generateInvoice.py
@@ -1,28 +1,31 @@
 #!/usr/bin/env python3
 import io
 from datetime import datetime
-from pypdf import PdfReader, PdfWriter 
+from pypdf import PdfReader, PdfWriter
 from reportlab.pdfgen import canvas
 from reportlab.lib.pagesizes import letter
 
+
 def fill_invoice(template_path, output_path, invoice_data):
-    # 1) Create a PDF in memory with your dynamic fields
+    """Fill a PDF invoice template with the provided data."""
+    # 1) Create a PDF in memory with dynamic fields
     packet = io.BytesIO()
     can = canvas.Canvas(packet, pagesize=letter)
 
-    # Example coordinates—tweak these to match your template
-    can.drawString( 70, 730, invoice_data['client_name'])
+    # Example coordinates—adjust to match the template
+    can.drawString(70, 730, invoice_data['client_name'])
     can.drawString(400, 730, invoice_data['period'])
-    can.drawString( 70, 700, datetime.strptime(invoice_data['date'], '%Y-%m-%d').strftime('%-m/%-d/%y'))
+    date_obj = datetime.strptime(invoice_data['date'], '%Y-%m-%d')
+    can.drawString(70, 700, date_obj.strftime('%-m/%-d/%y'))
     can.drawString(400, 700, f"$ {invoice_data['amount']:.2f}")
 
     can.save()
     packet.seek(0)
 
-    # 2) Read the template PDF
+    # 2) Read the template PDF and overlay
     template_pdf = PdfReader(template_path)
-    overlay_pdf  = PdfReader(packet)
-    writer       = PdfWriter()
+    overlay_pdf = PdfReader(packet)
+    writer = PdfWriter()
 
     # 3) Merge the overlay onto the first page
     page = template_pdf.pages[0]
@@ -33,13 +36,14 @@ def fill_invoice(template_path, output_path, invoice_data):
     with open(output_path, 'wb') as f:
         writer.write(f)
 
+
 if __name__ == '__main__':
     # Example usage with dummy data
     invoice = {
-        'client_name':  'Tarek El Tayeh',
-        'period':       'May 1st to May 31st 2025',
-        'date':         '2025-05-01',
-        'amount':       135.38,
+        'client_name': 'Tarek El Tayeh',
+        'period': 'May 1st to May 31st 2025',
+        'date': '2025-05-01',
+        'amount': 135.38,
     }
     fill_invoice('invoice.pdf', 'filled_invoice.pdf', invoice)
-    print("Generated filled_invoice.pdf")
+    print('Generated filled_invoice.pdf')

--- a/generate_invoices.py
+++ b/generate_invoices.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Generate invoices for each client from transaction JSON."""
+
+import argparse
+import json
+import os
+import sqlite3
+from collections import defaultdict
+from datetime import date
+
+from generateInvoice import fill_invoice
+
+
+def load_client_names(db_path: str) -> dict:
+    """Return a mapping of client_code -> client_name from the SQLite DB."""
+    conn = sqlite3.connect(db_path)
+    cur = conn.cursor()
+    cur.execute(
+        'SELECT "Unnamed: 1" AS code, "Unnamed: 2" AS name '\
+        'FROM clients WHERE "Unnamed: 1" != "" AND "Unnamed: 1" != "Code"'
+    )
+    mapping = {code: name for code, name in cur.fetchall()}
+    conn.close()
+    return mapping
+
+
+def group_transactions(json_path: str) -> dict:
+    """Group transaction records by client_code."""
+    with open(json_path, 'r', encoding='utf-8') as f:
+        records = json.load(f)
+    groups = defaultdict(list)
+    for rec in records:
+        groups[rec['client_code']].append(rec)
+    return groups
+
+
+def build_invoice_data(client_name: str, records: list) -> dict:
+    amounts = [r['price'] for r in records]
+    dates = [r['date'] for r in records]
+    period = f"{min(dates)} to {max(dates)}" if dates else ""
+    return {
+        'client_name': client_name,
+        'period': period,
+        'date': date.today().isoformat(),
+        'amount': sum(amounts),
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description='Generate one invoice PDF per client based on transaction JSON.'
+    )
+    parser.add_argument('json_file', help='Path to transactions.json produced by parse_transactions')
+    parser.add_argument('template', help='Invoice PDF template path')
+    parser.add_argument('--db', default='database/bistro54_clients.db', help='SQLite database of clients')
+    parser.add_argument('--out-dir', default='.', help='Directory to store generated invoices')
+    args = parser.parse_args()
+
+    client_names = load_client_names(args.db)
+    grouped = group_transactions(args.json_file)
+    os.makedirs(args.out_dir, exist_ok=True)
+
+    for code, records in grouped.items():
+        name = client_names.get(code, f'Client {code}')
+        invoice_data = build_invoice_data(name, records)
+        output_path = os.path.join(args.out_dir, f'filled_invoice_{code}.pdf')
+        fill_invoice(args.template, output_path, invoice_data)
+        print(f'Generated {output_path}')
+
+
+if __name__ == '__main__':
+    main()

--- a/parse_transactions.py
+++ b/parse_transactions.py
@@ -91,11 +91,20 @@ def export_data(records, csv_path, json_path):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
-        description="Extract transaction details from a PDF and export to CSV/JSON")
-    
-    parser.add_argument("pdf file", help="Path to the transaction PDF")
-    parser.add_argument("--csv", default="transactions.csv", help="output CSV file parth")
-    parser.add_argument("--json", default="transactions.json", help="Output JSON file path")
+        description="Extract transaction details from a PDF and export to CSV/JSON",
+    )
+
+    parser.add_argument("pdf_file", help="Path to the transaction PDF")
+    parser.add_argument(
+        "--csv",
+        default="transactions.csv",
+        help="Output CSV file path",
+    )
+    parser.add_argument(
+        "--json",
+        default="transactions.json",
+        help="Output JSON file path",
+    )
     args = parser.parse_args()
 
     records = parse_transaction_pdf(args.pdf_file)


### PR DESCRIPTION
## Summary
- introduce `generate_invoices.py` to group transaction data by client and create PDF invoices using the client database
- extend `generateInvoice.py` and Makefile to support batch invoice generation via a new `batch-invoices` target
- document the end-to-end workflow for parsing, batch invoicing, and cleanup

## Testing
- `python -m py_compile parse_transactions.py txt_journal_parser.py cleanup_outputs.py generateInvoice.py generate_invoices.py`
- `python generate_invoices.py --help` *(fails: No module named 'pypdf')*
- `python parse_transactions.py --help` *(fails: No module named 'pdfplumber')*
- `make help`
- `make batch-invoices` *(fails: No module named 'pypdf')*
- `make clean`


------
https://chatgpt.com/codex/tasks/task_b_6895fc966f748321bcebbe82c24fb7ae