### PR TITLE
fix: capture multi-word employee names

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ This project provides scripts to:
 ├── README.md
 ├── txt_journal_parser.py # Parses TXT dumps to CSV/JSON/Excel
 ├── parse_transactions.py # Extracts detailed transactions from PDF
-├── generateInvoice.py # Fills PDF invoice template with data
+├── generate_invoice.py # Fills PDF invoice template with data
 ├── cleanup_outputs.py # Deletes generated CSV/JSON/Excel/PDF files
 ├── invoice.pdf # Blank invoice template
 └── venv/ # Python virtual environment
@@ -82,13 +82,13 @@ python3 txt_journal_parser.py path/to/journal.txt \
 
 3. Generate Invoices
 
-python3 generateInvoice.py invoice.pdf filled_invoice.pdf
+python3 generate_invoice.py invoice.pdf filled_invoice.pdf
 
     invoice.pdf: Path to your blank template.
 
     filled_invoice.pdf: Destination for the populated invoice.
 
-Customize generateInvoice.py to loop over parsed data and produce one PDF per customer or per day.
+Customize generate_invoice.py to loop over parsed data and produce one PDF per customer or per day.
 4. Cleanup Outputs
 
 python3 cleanup_outputs.py --csv ar.csv --json ar.json --excel ar.xlsx

--- a/import_clients.py
+++ b/import_clients.py
@@ -9,7 +9,7 @@ Usage:
     python3 import_clients.py --db path/to/database.db --input client_list.xlsx
 
 The input file should contain at least the following columns:
-    Code, Name, Phone, Adress(1), Adress(2), Prepaid balance,
+    Code, Name, Phone, Address(1), Address(2), Prepaid balance,
     Owed amount, E-Mail (optional)
 
 CSV files are supported as well. Column names are case‑insensitive.
@@ -38,7 +38,7 @@ def import_clients(db_path: str, input_path: str) -> None:
     # Normalise column names
     df.columns = normalise_column_names(df.columns)
     # Expected columns
-    # code, name, phone, adress1, adress2, prepaid_balance,
+    # code, name, phone, address1, address2, prepaid_balance,
     # owed_amount, e_mail
     # Some spreadsheets may name address columns differently
     mapping: Dict[str, str] = {

--- a/parse_transactions.py
+++ b/parse_transactions.py
@@ -43,7 +43,7 @@ def parse_transaction_pdf(pdf_path: str) -> List[Dict[str, str]]:
         r'(?P<date>\d{1,2}/\d{1,2}/\d{2})\s+'
         r'(?P<time>\d{1,2}:\d{2})\s+'
         r'#?(?P<ref>\d+)\s+'
-        r'(?P<emp>\S+)'
+        r'(?P<emp>.+)'
     )
 
     with pdfplumber.open(pdf_path) as pdf:
@@ -63,7 +63,7 @@ def parse_transaction_pdf(pdf_path: str) -> List[Dict[str, str]]:
                     info['date'] = f"{yyyy}-{int(mm):02d}-{int(dd):02d}"
                     info['client_code'] = info.pop('code')
                     info['reference'] = info.pop('ref')
-                    info['employee'] = info.pop('emp')
+                    info['employee'] = info.pop('emp').strip()
                     header_info = info
                 else:
                     # Attempt to parse item line: description + price at end


### PR DESCRIPTION
## Summary
- fix address column names in import_clients description
- capture multi-word employee names in transactions parser
- reference generate_invoice.py in README

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_6896097875248321916b4b99bf2a2fa3